### PR TITLE
Generalize for any repo

### DIFF
--- a/3rdparty-over-time.plot
+++ b/3rdparty-over-time.plot
@@ -24,7 +24,8 @@ set ytics 2
 set xtics rotate 3600*24*365.25 nomirror
 unset mxtics
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/50-percent.plot
+++ b/50-percent.plot
@@ -27,7 +27,8 @@ unset mxtics
 set xrange ["1999-06-01":]
 set yrange [0:]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/60-percent.plot
+++ b/60-percent.plot
@@ -27,7 +27,8 @@ unset mxtics
 set xrange ["1999-06-01":]
 set yrange [0:]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/70-percent.plot
+++ b/70-percent.plot
@@ -27,7 +27,8 @@ unset mxtics
 set xrange ["1999-06-01":]
 set yrange [0:]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/80-percent.plot
+++ b/80-percent.plot
@@ -27,7 +27,8 @@ unset mxtics
 set xrange ["1999-06-01":]
 set yrange [0:]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/90-percent.plot
+++ b/90-percent.plot
@@ -27,7 +27,8 @@ unset mxtics
 set xrange ["1999-06-01":]
 set yrange [0:]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/95-percent.plot
+++ b/95-percent.plot
@@ -27,7 +27,8 @@ unset mxtics
 set xrange ["1999-06-01":]
 set yrange [0:]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/API-calls-over-time.plot
+++ b/API-calls-over-time.plot
@@ -26,7 +26,8 @@ set ytics nomirror
 
 set yrange [0:]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/CI-jobs-over-time.plot
+++ b/CI-jobs-over-time.plot
@@ -18,7 +18,8 @@ set timefmt "%Y-%m-%d"
 set xdata time
 set xrange ["2013-08-01":]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/CI-platforms.plot
+++ b/CI-platforms.plot
@@ -17,7 +17,8 @@ unset border
 set timefmt "%Y-%m-%d"
 set xdata time
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/CI-services.plot
+++ b/CI-services.plot
@@ -18,7 +18,8 @@ set timefmt "%Y-%m-%d"
 set xdata time
 set xrange ["2013-08-01":]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/added-per-line.plot
+++ b/added-per-line.plot
@@ -28,7 +28,8 @@ set xdata time
 set yrange [1:]
 set xrange ["2000-03-01":]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.15 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/authorremains-top.plot
+++ b/authorremains-top.plot
@@ -25,7 +25,8 @@ set timefmt "%Y-%m-%d"
 set xdata time
 set xrange ["2010-01-01":]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/authorremains.plot
+++ b/authorremains.plot
@@ -37,7 +37,8 @@ set timefmt "%Y-%m-%d"
 set xdata time
 set xrange ["2010-01-01":]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/authors-active.plot
+++ b/authors-active.plot
@@ -29,7 +29,8 @@ set xtics rotate 3600*24*365.25 nomirror
 set ytics 10 nomirror
 unset mxtics
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/authors-per-month.plot
+++ b/authors-per-month.plot
@@ -31,7 +31,8 @@ set style line 2 \
     linecolor rgb '#ff60ad' \
     dt 1 linewidth 4
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/authors-per-year.plot
+++ b/authors-per-year.plot
@@ -21,7 +21,8 @@ unset border
 set timefmt "%Y-%m-%d"
 set xdata time
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/authors.plot
+++ b/authors.plot
@@ -40,7 +40,8 @@ set xtics rotate 3600*24*365.25 nomirror
 unset mxtics
 set ytics nomirror
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/backends-over-time.plot
+++ b/backends-over-time.plot
@@ -55,7 +55,8 @@ set ytics 1 nomirror
 set xtics rotate 3600*24*365.25 nomirror
 unset mxtics
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/bugbounty-amounts.plot
+++ b/bugbounty-amounts.plot
@@ -23,7 +23,8 @@ set style line 1 \
     linecolor rgb '#ff8040' \
     linetype 1 linewidth 4
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 set datafile separator ";"

--- a/bugbounty-over-time.plot
+++ b/bugbounty-over-time.plot
@@ -28,7 +28,8 @@ set ytics nomirror
 set yrange [0:]
 set xrange ["2018-01-01":]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/bugfix-frequency.plot
+++ b/bugfix-frequency.plot
@@ -32,7 +32,8 @@ unset border
 set timefmt "%Y-%m-%d"
 set xdata time
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/c-vuln-over-time.plot
+++ b/c-vuln-over-time.plot
@@ -18,7 +18,8 @@ set y2tics
 set timefmt "%Y-%m-%d"
 set xdata time
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/c-vuln-reports.plot
+++ b/c-vuln-reports.plot
@@ -18,7 +18,8 @@ set y2tics
 set timefmt "%Y-%m-%d"
 set xdata time
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/cmdline-options-over-time.plot
+++ b/cmdline-options-over-time.plot
@@ -24,7 +24,8 @@ set xtics 3600*24*365.25 nomirror rotate out
 set ytics 25 nomirror
 unset mxtics
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/codeage.plot
+++ b/codeage.plot
@@ -26,7 +26,8 @@ unset mxtics
 set y2tics mirror out
 unset ytics
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30
 
 # set the format of the dates on the x axis

--- a/comments.plot
+++ b/comments.plot
@@ -22,7 +22,8 @@ set timefmt "%Y-%m-%d"
 set xdata time
 set yrange [0:]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/commits-over-time.plot
+++ b/commits-over-time.plot
@@ -30,7 +30,8 @@ set xtics rotate 3600*24*365.25 nomirror out
 unset mxtics
 set ytics nomirror
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/commits-per-month.plot
+++ b/commits-per-month.plot
@@ -37,7 +37,8 @@ set ytics nomirror
 set xtics 3600*24*365.25 nomirror rotate out
 unset mxtics
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/commits-per-year.plot
+++ b/commits-per-year.plot
@@ -27,7 +27,8 @@ set ytics nomirror
 set xrange ["1999-06-01":]
 set yrange [0:]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/complexity.plot
+++ b/complexity.plot
@@ -27,7 +27,8 @@ set xtics rotate 3600*24*365.25 nomirror out
 set ytics nomirror
 unset mxtics
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 set yrange [0:]

--- a/contrib-tail.plot
+++ b/contrib-tail.plot
@@ -21,7 +21,9 @@ set style line 1 \
 set grid
 unset border
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 set datafile separator ";"

--- a/contributors-over-time.plot
+++ b/contributors-over-time.plot
@@ -27,7 +27,8 @@ set xdata time
 # start Y at 0
 set yrange [0:]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/contributors-per-release.plot
+++ b/contributors-per-release.plot
@@ -33,7 +33,8 @@ set ytics nomirror
 unset mxtics
 set xrange ["2005-01-01":]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/coreteam-per-year.plot
+++ b/coreteam-per-year.plot
@@ -31,7 +31,9 @@ set xrange ["1999-06-01":]
 set yrange [0:]
 set y2range [0:]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/cpy-over-time.plot
+++ b/cpy-over-time.plot
@@ -37,7 +37,8 @@ set timefmt "%Y-%m-%d"
 set xdata time
 set yrange [0:]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/cve-age.plot
+++ b/cve-age.plot
@@ -41,7 +41,8 @@ set style line 7 \
     linecolor rgb '#800080' \
     linetype 1 linewidth 1
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 set datafile separator ";"

--- a/cve-fixtime.plot
+++ b/cve-fixtime.plot
@@ -29,7 +29,8 @@ set style line 3 \
     linecolor rgb '#FF0040' \
     linetype 1 linewidth 2
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 set datafile separator ";"

--- a/cve-pie-chart.plot
+++ b/cve-pie-chart.plot
@@ -34,7 +34,8 @@ unset key                  # no automatic labels
 unset tics                 # remove tics
 unset border               # remove borders; if some label is missing, comment to see what is happening
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.28, 0.30 width screen 0.20 front
 
 set size ratio -1              # equal scale length

--- a/daniel-commit-share.plot
+++ b/daniel-commit-share.plot
@@ -28,7 +28,8 @@ set xrange ["1999-10-01":]
 set boxwidth 0.5 relative
 set style fill solid
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/daniel-vs-rest.plot
+++ b/daniel-vs-rest.plot
@@ -37,7 +37,8 @@ set xrange ["1999-10-01":]
 set boxwidth 0.5 relative
 set style fill solid
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/date-of-year.plot
+++ b/date-of-year.plot
@@ -27,7 +27,8 @@ set xtics 3600*24*30.44 nomirror out offset 4
 set ytics out nomirror
 unset mxtics
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/days-per-release.plot
+++ b/days-per-release.plot
@@ -32,7 +32,8 @@ set xtics rotate 3600*24*365.25 nomirror out
 set ytics 10 nomirror
 unset mxtics
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/docs-over-time.plot
+++ b/docs-over-time.plot
@@ -24,7 +24,8 @@ set xtics rotate 3600*24*365.25 nomirror
 set ytics nomirror
 unset mxtics
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/donations.plot
+++ b/donations.plot
@@ -43,7 +43,8 @@ day = 24*hour
 
 set xtics 30*day rotate nomirror
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/examples-over-time.plot
+++ b/examples-over-time.plot
@@ -26,7 +26,8 @@ unset mxtics
 
 set yrange [0:]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/files-over-time.plot
+++ b/files-over-time.plot
@@ -28,7 +28,8 @@ set xtics 3600*24*365.25 nomirror rotate
 set ytics nomirror
 unset mxtics
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/filesize-over-time.plot
+++ b/filesize-over-time.plot
@@ -32,7 +32,8 @@ set xdata time
 set yrange [0:]
 set xrange ["2002-01-01":]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/firsttimers.plot
+++ b/firsttimers.plot
@@ -27,7 +27,8 @@ set xdata time
 set boxwidth 0.8 relative
 set style fill solid
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/funclen.plot
+++ b/funclen.plot
@@ -26,7 +26,8 @@ set xtics rotate 3600*24*365.25 nomirror out
 set ytics nomirror
 unset mxtics
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 set yrange [0:]

--- a/gh-age.plot
+++ b/gh-age.plot
@@ -40,7 +40,8 @@ set xtics 3600*24*365.25 nomirror out
 set ytics nomirror
 unset mxtics
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/gh-fixes.plot
+++ b/gh-fixes.plot
@@ -38,7 +38,8 @@ set ytics nomirror
 set yrange [0:]
 set xrange ["2015-10-01":]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/gh-monthly-open.plot
+++ b/gh-monthly-open.plot
@@ -37,7 +37,8 @@ set ytics nomirror
 set yrange [0:]
 set xrange ["2015-03-01":]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/gh-monthly.plot
+++ b/gh-monthly.plot
@@ -39,7 +39,8 @@ set xtics 3600*24*365.25 nomirror out
 set ytics nomirror
 unset mxtics
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/gh-open.plot
+++ b/gh-open.plot
@@ -31,7 +31,8 @@ set ytics 10 nomirror
 set yrange [0:]
 set xrange ["2015-03-01":]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/github-cache.pl
+++ b/github-cache.pl
@@ -70,7 +70,9 @@ my $i = decode_json(join("", @j));
 #print Dumper($i);
 my $lastnum = $$i[0]{number};
 
-if($lastnum < 6592) {
+use Scalar::Util qw(looks_like_number);
+
+unless(looks_like_number($lastnum)) {
     print STDERR "Error, bail out!\n";
     exit;
 }

--- a/github-cache.pl
+++ b/github-cache.pl
@@ -70,9 +70,7 @@ my $i = decode_json(join("", @j));
 #print Dumper($i);
 my $lastnum = $$i[0]{number};
 
-use Scalar::Util qw(looks_like_number);
-
-unless(looks_like_number($lastnum)) {
+unless($lastnum =~ /^\d+\z/) {
     print STDERR "Error, bail out!\n";
     exit;
 }

--- a/github-cache.pl
+++ b/github-cache.pl
@@ -71,7 +71,7 @@ my $i = decode_json(join("", @j));
 my $lastnum = $$i[0]{number};
 
 unless($lastnum =~ /^\d+\z/) {
-    print STDERR "Error, bail out!\n";
+    die "Error fetching last issue. Got: $lastnum";
     exit;
 }
 

--- a/github-json.pl
+++ b/github-json.pl
@@ -9,6 +9,20 @@ use JSON;
 #use Data::Dumper;
 my $cache="stats/gh-cache";
 
+use Getopt::Long;
+use Pod::Usage;
+
+my $man = 0;
+my $help = 0;
+
+GetOptions ('cache=s' => \$cache,
+            'help|?' => \$help,
+            man => \$man) or pod2usage(2);
+
+pod2usage(1) if $help;
+pod2usage(-exitval => 0, -verbose => 2) if $man;
+
+
 my @json;
 if($ARGV[0] ne "") {
     push @json, @ARGV;

--- a/graphs.plot
+++ b/graphs.plot
@@ -33,7 +33,8 @@ set xdata time
 # start Y at 0
 set yrange [0:]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/high-vuln-reports.plot
+++ b/high-vuln-reports.plot
@@ -18,7 +18,8 @@ unset border
 set timefmt "%Y-%m-%d"
 set xdata time
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.15, 0.25 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/http-over-time.plot
+++ b/http-over-time.plot
@@ -26,7 +26,8 @@ set ytics 1 nomirror
 set xtics 3600*24*365.25 nomirror rotate
 unset mxtics
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/knownvulns-per-line.plot
+++ b/knownvulns-per-line.plot
@@ -26,7 +26,8 @@ unset mxtics
 set yrange [0:]
 set xrange ["2000-01-01":]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/lines-over-time.plot
+++ b/lines-over-time.plot
@@ -29,7 +29,8 @@ unset border
 set timefmt "%Y-%m-%d"
 set xdata time
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/lines-per-author.plot
+++ b/lines-per-author.plot
@@ -30,7 +30,8 @@ unset mxtics
 set yrange [0:]
 set xrange ["2005-01-01":]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/lines-per-docs.plot
+++ b/lines-per-docs.plot
@@ -25,7 +25,8 @@ set yrange [0:]
 set ytics nomirror
 unset mxtics
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/lines-per-knownvulns.plot
+++ b/lines-per-knownvulns.plot
@@ -24,7 +24,8 @@ set xtics rotate 3600*24*365.25 nomirror
 set yrange [0:]
 set xrange [:"2023-02-01"]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/lines-per-month.plot
+++ b/lines-per-month.plot
@@ -43,10 +43,12 @@ set xtics rotate 3600*24*365.25 nomirror
 set ytics nomirror
 unset mxtics
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/lines-per-test.plot
+++ b/lines-per-test.plot
@@ -25,7 +25,8 @@ set yrange [0:]
 set ytics 1 nomirror
 unset mxtics
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/lines-person.plot
+++ b/lines-person.plot
@@ -39,7 +39,8 @@ unset mxtics
 set yrange [0:]
 set xrange ["1999-12-01":]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/mail.plot
+++ b/mail.plot
@@ -41,7 +41,8 @@ set xtics rotate 3600*24*365.25 nomirror out
 set ytics nomirror
 unset mxtics
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/manpages-over-time.plot
+++ b/manpages-over-time.plot
@@ -26,7 +26,8 @@ unset mxtics
 
 set yrange [0:]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/mksvg.sh
+++ b/mksvg.sh
@@ -1,5 +1,9 @@
 #!bin/sh
 
+# Uncomment to debug this script:
+set -x
+#set -e
+
 # custom dir for the web root directory
 webroot=$1
 
@@ -8,77 +12,85 @@ temp=tmp
 # store the SVG output here
 output=`mktemp -d svg-XXXXXX`
 
-perl stats/date-of-year.pl > $temp/date-of-year.csv
+generate_csv () {
+    perl stats/$1.pl $2 > $temp/$1.csv
+}
+
+generate_plot () {
+    gnuplot -c stats/$1.plot > $output/$1.svg
+}
+
+generate_csv date-of-year
 gnuplot -c stats/date-of-year.plot > $output/date-of-year.svg
 
-perl stats/month-of-year.pl > $temp/month-of-year.csv
+generate_csv month-of-year
 gnuplot -c stats/month-of-year.plot > $output/month-of-year.svg
 
-perl stats/weekday-of-year.pl > $temp/weekday-of-year.csv
+generate_csv weekday-of-year
 gnuplot -c stats/weekday-of-year.plot > $output/weekday-of-year.svg
 
-perl stats/contrib-tail.pl > $temp/contrib-tail.csv
+generate_csv contrib-tail
 gnuplot -c stats/contrib-tail.plot > $output/contrib-tail.svg
 
-perl stats/mail.pl > $temp/mail.csv
+generate_csv mail
 gnuplot -c stats/mail.plot > $output/mail.svg
 
 perl stats/github-json.pl > $temp/github.csv
-perl stats/gh-monthly.pl $temp/github.csv > $temp/gh-monthly.csv
+generate_csv gh-monthly $temp/github.csv
 gnuplot -c stats/gh-monthly.plot > $output/gh-monthly.svg
 
-perl stats/gh-open.pl $temp/github.csv > $temp/gh-open.csv
+generate_csv gh-open $temp/github.csv
 gnuplot -c stats/gh-open.plot > $output/gh-open.svg
 
-perl stats/gh-age.pl $temp/github.csv > $temp/gh-age.csv
+generate_csv gh-age $temp/github.csv
 gnuplot -c stats/gh-age.plot > $output/gh-age.svg
 
-perl stats/gh-fixes.pl $temp/github.csv > $temp/gh-fixes.csv
+generate_csv gh-fixes $temp/github.csv
 gnuplot -c stats/gh-fixes.plot > $output/gh-fixes.svg
 
-perl stats/files-over-time.pl > $temp/files-over-time.csv
+generate_csv files-over-time
 gnuplot -c stats/files-over-time.plot > $output/files-over-time.svg
 
-perl stats/bugfix-frequency.pl $webroot > $temp/bugfix-frequency.csv
+generate_csv bugfix-frequency $webroot
 gnuplot -c stats/bugfix-frequency.plot > $output/bugfix-frequency.svg
 
-perl stats/API-calls-over-time.pl > $temp/API-calls-over-time.csv
+generate_csv API-calls-over-time
 gnuplot -c stats/API-calls-over-time.plot > $output/API-calls-over-time.svg
 
-perl stats/protocols-over-time.pl > $temp/protocols-over-time.csv
+generate_csv protocols-over-time
 gnuplot -c stats/protocols-over-time.plot > $output/protocols-over-time.svg
 
-perl stats/tls-over-time.pl > $temp/tls-over-time.csv
-perl stats/ssh-over-time.pl > $temp/ssh-over-time.csv
-perl stats/h1-over-time.pl > $temp/h1-over-time.csv
-perl stats/h2-over-time.pl > $temp/h2-over-time.csv
-perl stats/h3-over-time.pl > $temp/h3-over-time.csv
-perl stats/idn-over-time.pl > $temp/idn-over-time.csv
-perl stats/resolver-over-time.pl > $temp/resolver-over-time.csv
+generate_csv tls-over-time
+generate_csv ssh-over-time
+generate_csv h1-over-time
+generate_csv h2-over-time
+generate_csv h3-over-time
+generate_csv idn-over-time
+generate_csv resolver-over-time
 gnuplot -c stats/backends-over-time.plot > $output/backends-over-time.svg
 
-perl stats/3rdparty-over-time.pl > $temp/3rdparty-over-time.csv
+generate_csv 3rdparty-over-time
 gnuplot -c stats/3rdparty-over-time.plot > $output/3rdparty-over-time.svg
 
-perl stats/http-over-time.pl > $temp/http-over-time.csv
+generate_csv http-over-time
 gnuplot -c stats/http-over-time.plot > $output/http-over-time.svg
 
-perl stats/daniel-vs-rest.pl > $temp/daniel-vs-rest.csv
+generate_csv daniel-vs-rest
 gnuplot -c stats/daniel-vs-rest.plot > $output/daniel-vs-rest.svg
 
-perl stats/daniel-commit-share.pl > $temp/daniel-commit-share.csv
+generate_csv daniel-commit-share
 gnuplot -c stats/daniel-commit-share.plot > $output/daniel-commit-share.svg
 
-perl stats/authors-per-year.pl > $temp/authors-per-year.csv
+generate_csv authors-per-year
 gnuplot -c stats/authors-per-year.plot > $output/authors-per-year.svg
 
-perl stats/authors-active.pl > $temp/authors-active.csv
+generate_csv authors-active
 gnuplot -c stats/authors-active.plot > $output/authors-active.svg
 
-perl stats/commits-per-year.pl > $temp/commits-per-year.csv
+generate_csv commits-per-year
 gnuplot -c stats/commits-per-year.plot > $output/commits-per-year.svg
 
-perl stats/commits-over-time.pl > $temp/commits-over-time.csv
+generate_csv commits-over-time
 gnuplot -c stats/commits-over-time.plot > $output/commits-over-time.svg
 
 perl stats/coreteam-over-time.pl | grep "^[12]" | tr -d '(' | awk '{ print $1"-01-01;"$2; }' > $temp/coreteam-per-year.csv
@@ -98,10 +110,10 @@ gnuplot -c stats/70-percent.plot > $output/70-percent.svg
 gnuplot -c stats/60-percent.plot > $output/60-percent.svg
 gnuplot -c stats/50-percent.plot > $output/50-percent.svg
 
-perl stats/comments.pl > $temp/comments.csv
+generate_csv comments
 gnuplot -c stats/comments.plot > $output/comments.svg
 
-perl stats/filesize-over-time.pl > $temp/filesize-over-time.csv
+generate_csv filesize-over-time
 gnuplot -c stats/filesize-over-time.plot > $output/filesize-over-time.svg
 
 perl stats/setopts-over-time.pl | cut '-d;' -f2- > $temp/setopts-over-time.csv
@@ -110,42 +122,42 @@ gnuplot -c stats/setopts-over-time.plot > $output/setopts-over-time.svg
 perl stats/days-per-release.pl $webroot > $temp/days-per-release.csv
 gnuplot -c stats/days-per-release.plot > $output/days-per-release.svg
 
-perl stats/cmdline-options-over-time.pl > $temp/cmdline-options-over-time.csv
+generate_csv cmdline-options-over-time
 gnuplot -c stats/cmdline-options-over-time.plot > $output/cmdline-options-over-time.svg
 
 perl stats/contributors-over-time.pl | cut '-d;' -f2- > $temp/contributors-over-time.csv
 gnuplot -c stats/contributors-over-time.plot > $output/contributors-over-time.svg
 
-perl stats/authors.pl > $temp/authors.csv
+generate_csv authors
 gnuplot -c stats/authors.plot > $output/authors.svg
 
-perl stats/authorremains.pl > $temp/authorremains.csv
+generate_csv authorremains
 gnuplot -c stats/authorremains.plot > $output/authorremains.svg
 gnuplot -c stats/authorremains-top.plot > $output/authorremains-top.svg
 
-perl stats/todo-over-time.pl > $temp/todo-over-time.csv
+generate_csv todo-over-time
 gnuplot -c stats/todo-over-time.plot > $output/todo-over-time.svg
 
-perl stats/symbols-over-time.pl > $temp/symbols-over-time.csv
+generate_csv symbols-over-time
 gnuplot -c stats/symbols-over-time.plot > $output/symbols-over-time.svg
 
-perl stats/authors-per-month.pl > $temp/authors-per-month.csv
+generate_csv authors-per-month
 gnuplot -c stats/authors-per-month.plot > $output/authors-per-month.svg
 
-perl stats/firsttimers.pl > $temp/firsttimers.csv
+generate_csv firsttimers
 gnuplot -c stats/firsttimers.plot > $output/firsttimers.svg
 
 perl stats/CI-jobs-over-time.pl | cut '-d;' -f2-  > $temp/CI.csv
 gnuplot -c stats/CI-jobs-over-time.plot > $output/CI-jobs-over-time.svg
 gnuplot -c stats/CI-services.plot > $output/CI-services.svg
 
-perl stats/CI-platforms.pl > $temp/CI-platforms.csv
+generate_csv CI-platforms
 gnuplot -c stats/CI-platforms.plot > $output/CI-platforms.svg
 
-perl stats/commits-per-month.pl > $temp/commits-per-month.csv
+generate_csv commits-per-month
 gnuplot -c stats/commits-per-month.plot > $output/commits-per-month.svg
 
-perl stats/docs-over-time.pl > $temp/docs-over-time.csv
+generate_csv docs-over-time
 gnuplot -c stats/docs-over-time.plot > $output/docs-over-time.svg
 
 perl stats/vulns-releases.pl $webroot > $temp/vulns-releases.csv
@@ -179,16 +191,16 @@ gnuplot -c stats/sev-per-year.plot > $output/sev-per-year.svg
 perl stats/lines-over-time.pl > $temp/lines-over-time.csv
 gnuplot -c stats/lines-over-time.plot > $output/lines-over-time.svg
 
-perl stats/lines-per-month.pl > $temp/lines-per-month.csv
+generate_csv lines-per-month
 gnuplot -c stats/lines-per-month.plot > $output/lines-per-month.svg
 
-perl stats/tests-over-time.pl > $temp/tests-over-time.csv
+generate_csv tests-over-time
 gnuplot -c stats/tests-over-time.plot > $output/tests-over-time.svg
 
-perl stats/manpages-over-time.pl > $temp/manpages-over-time.csv
+generate_csv manpages-over-time
 gnuplot -c stats/manpages-over-time.plot > $output/manpages-over-time.svg
 
-perl stats/examples-over-time.pl > $temp/examples-over-time.csv
+generate_csv examples-over-time
 gnuplot -c stats/examples-over-time.plot > $output/examples-over-time.svg
 
 perl stats/bugbounty-over-time.pl $webroot > $temp/bugbounty-over-time.csv
@@ -197,10 +209,10 @@ gnuplot -c stats/bugbounty-over-time.plot > $output/bugbounty-over-time.svg
 perl stats/bugbounty-amounts.pl $webroot > $temp/bugbounty-amounts.csv
 gnuplot -c stats/bugbounty-amounts.plot > $output/bugbounty-amounts.svg
 
-perl stats/contributors-per-release.pl > $temp/contributors-per-release.csv
+generate_csv contributors-per-release
 gnuplot -c stats/contributors-per-release.plot > $output/contributors-per-release.svg
 
-perl stats/lines-person.pl > $temp/lines-person.csv
+generate_csv lines-person
 gnuplot -c stats/lines-person.plot > $output/lines-person.svg
 
 perl stats/release-number.pl $webroot > $temp/release-number.csv
@@ -209,26 +221,26 @@ gnuplot -c stats/release-number.plot > $output/release-number.svg
 perl stats/releases-per-year.pl $webroot > $temp/releases-per-year.csv
 gnuplot -c stats/releases-per-year.plot > $output/releases-per-year.svg
 
-perl stats/cpy-over-time.pl > $temp/cpy-over-time.csv
+generate_csv cpy-over-time
 gnuplot -c stats/cpy-over-time.plot > $output/cpy-over-time.svg
 
-perl stats/strncpy-over-time.pl > $temp/strncpy-over-time.csv
+generate_csv strncpy-over-time
 gnuplot -c stats/strncpy-over-time.plot > $output/strncpy-over-time.svg
 
-perl stats/sscanf-over-time.pl > $temp/sscanf-over-time.csv
+generate_csv sscanf-over-time
 gnuplot -c stats/sscanf-over-time.plot > $output/sscanf-over-time.svg
 
-perl stats/complexity.pl > $temp/complexity.csv
+generate_csv complexity
 gnuplot -c stats/complexity.plot > $output/complexity.svg
 gnuplot -c stats/funclen.plot > $output/funclen.svg
 
-perl stats/codeage.pl > $temp/codeage.csv
+generate_csv codeage
 gnuplot -c stats/codeage.plot > $output/codeage.svg
 
 perl stats/top-cwe.pl $webroot > $temp/top-cwe.csv
 gnuplot -c stats/top-cwe.plot > $output/top-cwe.svg
 
-perl stats/testinfra-over-time.pl > $temp/testinfra-over-time.csv
+generate_csv testinfra-over-time
 gnuplot -c stats/testinfra-over-time.plot > $output/testinfra-over-time.svg
 
 perl stats/plotdivision.pl $temp/testinfra-over-time.csv $temp/lines-over-time.csv 0:1 0:1 1000 > $temp/testinfra-per-line.csv
@@ -238,7 +250,7 @@ perl stats/plotdivision.pl $temp/testinfra-over-time.csv $temp/tests-over-time.c
 gnuplot -c stats/testinfra-per-test.plot > $output/testinfra-per-test.svg
 
 # Added LOC per LOC still present
-perl stats/addedcode.pl > $temp/addedcode.csv
+generate_csv addedcode
 perl stats/plotdivision.pl $temp/addedcode.csv $temp/lines-over-time.csv  0:1 0:1 > $temp/added-per-line.csv
 gnuplot -c stats/added-per-line.plot > $output/added-per-line.svg
 
@@ -270,7 +282,7 @@ perl stats/plotdivision.pl $temp/authorremains.csv $temp/lines-over-time.csv 0:1
 gnuplot -c stats/remains-per-kloc.plot > $output/remains-per-kloc.svg
 
 # top-40 authors with production code remaining in master
-perl stats/top-remains.pl > $temp/top-remains.csv
+generate_csv top-remains
 gnuplot -c stats/top-remains.plot > $output/top-remains.svg
 
 # CVE severity pie chart

--- a/month-of-year.plot
+++ b/month-of-year.plot
@@ -24,7 +24,8 @@ set yrange [0:]
 # set the format of the dates on the x axis
 set datafile separator ";"
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 plot 'tmp/month-of-year.csv' using 1:3 with boxes fc "#606000" title "", \

--- a/planets-over-time.plot
+++ b/planets-over-time.plot
@@ -25,7 +25,8 @@ set xdata time
 set ytics 1
 set xtics 3600*24*365.25 nomirror rotate
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/protocols-over-time.plot
+++ b/protocols-over-time.plot
@@ -26,7 +26,8 @@ set timefmt "%Y-%m-%d"
 set xdata time
 set yrange [0:]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/release-number.plot
+++ b/release-number.plot
@@ -25,7 +25,8 @@ set xtics rotate 3600*24*365.25 nomirror out
 set ytics 25 nomirror
 unset mxtics
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/releases-per-year.plot
+++ b/releases-per-year.plot
@@ -29,7 +29,8 @@ unset ytics
 
 set yrange [0:]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/remains-per-kloc.plot
+++ b/remains-per-kloc.plot
@@ -26,7 +26,8 @@ unset mxtics
 set yrange [0:]
 set xrange ["2010-01-01":]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/setopts-over-time.plot
+++ b/setopts-over-time.plot
@@ -26,7 +26,8 @@ set xdata time
 
 set yrange [0:]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/sev-per-year.plot
+++ b/sev-per-year.plot
@@ -28,7 +28,8 @@ set xrange ["1998-01-01":]
 set mxtics 1
 set ytics nomirror
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/sscanf-over-time.plot
+++ b/sscanf-over-time.plot
@@ -29,7 +29,8 @@ set timefmt "%Y-%m-%d"
 set xdata time
 set yrange [0:]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/strncpy-over-time.plot
+++ b/strncpy-over-time.plot
@@ -29,7 +29,8 @@ set timefmt "%Y-%m-%d"
 set xdata time
 set yrange [0:]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/symbols-over-time.plot
+++ b/symbols-over-time.plot
@@ -27,7 +27,8 @@ set ytics nomirror
 set yrange [0:]
 set xrange ["2009-03-01":]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/testinfra-over-time.plot
+++ b/testinfra-over-time.plot
@@ -24,7 +24,8 @@ set xtics rotate 3600*24*365.25 nomirror
 set ytics nomirror
 unset mxtics
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/testinfra-per-line.plot
+++ b/testinfra-per-line.plot
@@ -25,7 +25,8 @@ set ytics nomirror
 unset mxtics
 set yrange [0:]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/testinfra-per-test.plot
+++ b/testinfra-per-test.plot
@@ -25,7 +25,8 @@ set ytics nomirror
 unset mxtics
 set yrange [0:]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/tests-over-time.plot
+++ b/tests-over-time.plot
@@ -33,7 +33,8 @@ unset mxtics
 
 set yrange [0:]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/tls-over-time.plot
+++ b/tls-over-time.plot
@@ -25,7 +25,8 @@ set xdata time
 set ytics 2
 set xtics rotate 3600*24*365.25 nomirror
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/todo-over-time.plot
+++ b/todo-over-time.plot
@@ -30,7 +30,8 @@ set xtics 3600*24*365.25 nomirror rotate
 set ytics nomirror
 unset mxtics
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/top-cwe.plot
+++ b/top-cwe.plot
@@ -23,7 +23,8 @@ set yrange [0:]
 # set the format of the dates on the x axis
 set datafile separator ";"
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 plot 'tmp/top-cwe.csv' using 1:3 with boxes fc "#f0d0d0" title "", \

--- a/top-remains.plot
+++ b/top-remains.plot
@@ -23,7 +23,8 @@ set yrange [0:]
 # set the format of the dates on the x axis
 set datafile separator ";"
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 plot 'tmp/top-remains.csv' using 1:3 with boxes fc "#a0a0e0" title "", \

--- a/vulns-over-time.plot
+++ b/vulns-over-time.plot
@@ -15,7 +15,8 @@ unset border
 set timefmt "%Y-%m-%d"
 set xdata time
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/vulns-per-year.plot
+++ b/vulns-per-year.plot
@@ -38,7 +38,8 @@ set mytics 5
 set xrange ["1998-01-01":]
 set mxtics 1
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/vulns-releases.plot
+++ b/vulns-releases.plot
@@ -32,7 +32,8 @@ set style fill solid
 
 set xrange ["2020-01-01":]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis

--- a/weekday-of-year.plot
+++ b/weekday-of-year.plot
@@ -21,7 +21,8 @@ unset xtics
 set ytics out nomirror
 set yrange [0:]
 
-set pixmap 1 "stats/curl-symbol-light.png"
+if (!exists("logo")) logo="stats/curl-symbol-light.png"
+set pixmap 1 logo
 set pixmap 1 at screen 0.35, 0.30 width screen 0.30 behind
 
 # set the format of the dates on the x axis


### PR DESCRIPTION
I love the [curl dashboard](https://curl.se/dashboard.html) and I want to use some of the stats for other projects. I forked this repository and started generalizing the scripts. For instance, github-cache.pl grabs a copy of issues in any repository. By default it still fetches curl issues. But if you provide another owner/repo, you can get issues from other repositories. Relevant to my interests, OpenSSL:

```
perl ./stats/github-cache.pl -owner openssl -repo openssl
```

I've gotten to a point where I'm going to want to remove curl-specific charts. (I love [Daniel vs. the rest](https://curl.se/dashboard1.html#daniel-vs-rest), but sadly Daniel Stenberg doesn't show up in _every_ GitHub repository.) Before I do that, I was curious if some of my changes would be useful to port back to this repository. If so, I'm happy to work with y'all to make a cleaner patch.