### PR TITLE
plots: use terminal include, use white background

### DIFF
--- a/3rdparty-over-time.plot
+++ b/3rdparty-over-time.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Third party libraries" font ",48"

--- a/50-percent.plot
+++ b/50-percent.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Number of persons authoring 50% of the commits" font ",48"

--- a/512-mb.plot
+++ b/512-mb.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "512MB download alloc spend" font ",48"

--- a/60-percent.plot
+++ b/60-percent.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Number of persons authoring 60% of the commits" font ",48"

--- a/70-percent.plot
+++ b/70-percent.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Number of persons authoring 70% of the commits" font ",48"

--- a/80-percent.plot
+++ b/80-percent.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Number of persons authoring 80% of the commits" font ",48"

--- a/90-percent.plot
+++ b/90-percent.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Number of persons authoring 90% of the commits" font ",48"

--- a/95-percent.plot
+++ b/95-percent.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Number of persons authoring 95% of the commits" font ",48"

--- a/API-calls-over-time.plot
+++ b/API-calls-over-time.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "API calls in libcurl" font ",48"

--- a/CI-jobs-over-time.plot
+++ b/CI-jobs-over-time.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Total number of CI jobs" font ",48"

--- a/CI-platforms.plot
+++ b/CI-platforms.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "CI jobs per platform" font ",48"

--- a/CI-services.plot
+++ b/CI-services.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "CI services" font ",48"

--- a/Makefile
+++ b/Makefile
@@ -513,7 +513,7 @@ $(GDIR)/authorremains.svg: $(INCLUDE) $(DDIR)/authorremains.csv
 $(DDIR)/authorremains.csv: $(SDIR)/authorremains.pl
 	$(GENCSV)
 
-$(GDIR)/authors.svg: $(INCLUDE) $(DDIR)/authors.csv
+$(GDIR)/authors.svg: $(INCLUDE) $(DDIR)/authors.csv $(SDIR)/authors.plot
 	$(GNUPLOT)
 $(DDIR)/authors.csv: $(SDIR)/authors.pl
 	$(GENCSV)

--- a/added-per-line.plot
+++ b/added-per-line.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Added LOC per LOC still present\n{/*0.6in product code only}" font ",48"

--- a/atoi-over-time.plot
+++ b/atoi-over-time.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "atoi function call density" font ",48"

--- a/authorremains-top.plot
+++ b/authorremains-top.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Authors with code left in product code\n{/*0.6 1K or more lines attributed to them by git blame -CCC}" font ",48"

--- a/authorremains.plot
+++ b/authorremains.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Authors with code left in product code\n{/*0.6lines attributed to them by git blame -CCC}" font ",48"

--- a/authors-active.plot
+++ b/authors-active.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Commit author activity" font ",48"

--- a/authors-per-month.plot
+++ b/authors-per-month.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Authors per month" font ",48"

--- a/authors-per-year.plot
+++ b/authors-per-year.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Commit authors per year" font ",48"

--- a/authors.plot
+++ b/authors.plot
@@ -1,5 +1,4 @@
-# SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Commit authors" font ",48"

--- a/backends-over-time.plot
+++ b/backends-over-time.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "backends" font ",48"

--- a/bugbounty-amounts.plot
+++ b/bugbounty-amounts.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Bug bounty rewards" font ",48"

--- a/bugbounty-over-time.plot
+++ b/bugbounty-over-time.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Accumulated curl bug-bounty payouts since 2018" font ",48"

--- a/bugfix-frequency.plot
+++ b/bugfix-frequency.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Bugfixes" font ",48"

--- a/c-vuln-code.plot
+++ b/c-vuln-code.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "C mistakes among the vulnerabilities present in code" font ",48"

--- a/c-vuln-reports.plot
+++ b/c-vuln-reports.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "C vulnerability share\n{/*0.4per report date}" font ",48"

--- a/cmdline-options-over-time.plot
+++ b/cmdline-options-over-time.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Command line options" font ",48"

--- a/codeage.plot
+++ b/codeage.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Source code age\n{/*0.5Lines of code written per two-year segment}" font ",48"

--- a/comments.plot
+++ b/comments.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 set title "Source code comment share" font ",48"
 set key bottom right
 

--- a/commit-sizes.plot
+++ b/commit-sizes.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 set title "Commit size distribution\n{/*.5As a share of commits done over a rolling 365 day period}" font ",48"
 set key bottom center horizontal out

--- a/commits-over-time.plot
+++ b/commits-over-time.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Commits" font ",48"

--- a/commits-per-month.plot
+++ b/commits-per-month.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Commits per month" font ",48"

--- a/commits-per-release.plot
+++ b/commits-per-release.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Commits per release" font ",48"

--- a/commits-per-year.plot
+++ b/commits-per-year.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Commits per year" font ",48"

--- a/complex-dist.plot
+++ b/complex-dist.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Complexity distribution\n{/*0.4How big share of the source code is considered how complex}" font ",48"

--- a/complexity.plot
+++ b/complexity.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Complexity\n{/*0.4Cyclomatic complexity used for the 99th percentile and worst function}" font ",48"

--- a/connectdata.plot
+++ b/connectdata.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "connectdata struct size" font ",48"

--- a/contrib-tail.plot
+++ b/contrib-tail.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "commit count per committer" font ",48"

--- a/contributors-over-time.plot
+++ b/contributors-over-time.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Contributors" font ",48"

--- a/contributors-per-release.plot
+++ b/contributors-per-release.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Contributors in RELEASE NOTES" font ",48"

--- a/coreteam-per-year.plot
+++ b/coreteam-per-year.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Core team size (10+ commits within the calendar year)" font ",48"

--- a/cpy-over-time.plot
+++ b/cpy-over-time.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Memory function call density" font ",48"

--- a/curlmopts-over-time.plot
+++ b/curlmopts-over-time.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "multi setopt options" font ",48"

--- a/cve-age.plot
+++ b/cve-age.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Vulnerability age" font ",48"

--- a/cve-fixtime.plot
+++ b/cve-fixtime.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Time from security report to shipped fix" font ",48"

--- a/cve-oldest.plot
+++ b/cve-oldest.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Top-20 longest lasting curl vulnerabilities\n{/*0.4Age the flaw had been present in code when made public}" font ",48"

--- a/cve-pie-chart.plot
+++ b/cve-pie-chart.plot
@@ -1,4 +1,4 @@
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 set title "CVE severity distribution" font ",48"
 
 filename = ARG1.'/cve-pie-chart.csv'

--- a/cvuln-per-year-intro.plot
+++ b/cvuln-per-year-intro.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Vulnerability reports C mistakes vs not C mistakes\n{/*0.6per year the vulnerability was introduced}" font ",48"

--- a/cvuln-per-year.plot
+++ b/cvuln-per-year.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Vulnerability reports C mistakes vs not C mistakes\n{/*0.6per year the vulnerability was published}" font ",48"

--- a/daniel-commit-share.plot
+++ b/daniel-commit-share.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Daniel Stenberg's share of committing changes\n{/*0.6separate from actually authoring the change}" font ",48"

--- a/daniel-vs-rest.plot
+++ b/daniel-vs-rest.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Daniel Stenberg's share of authored commits" font ",48"

--- a/date-of-year.plot
+++ b/date-of-year.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Commits per day of year" font ",48"

--- a/days-per-cmdline-option.plot
+++ b/days-per-cmdline-option.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Project days per new command line option" font ",48"

--- a/days-per-release.plot
+++ b/days-per-release.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Days between releases" font ",48"

--- a/docs-over-time.plot
+++ b/docs-over-time.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Lines of documentation" font ",48"

--- a/donations.plot
+++ b/donations.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Open Collective Donations to curl" font ",48"

--- a/donors.plot
+++ b/donors.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "sponsors at Open Collective" font ",48"

--- a/easy-handle.plot
+++ b/easy-handle.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Easy handle struct size" font ",48"

--- a/ec-words.plot
+++ b/ec-words.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Number of words in everything curl" font ",48"

--- a/examples-over-time.plot
+++ b/examples-over-time.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Stand-alone libcurl examples\n{/*0.4in the docs/examples subdirectory}" font ",48"

--- a/files-over-time.plot
+++ b/files-over-time.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Number of files in version control" font ",48"

--- a/filesize-over-time.plot
+++ b/filesize-over-time.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Lines per C file" font ",48"

--- a/firsttimers.plot
+++ b/firsttimers.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "First time commit authors" font ",48"

--- a/funclen.plot
+++ b/funclen.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Function length\n{/*0.4Lines of code for the 99th percentile and worst function. Includes comments and blank lines.}" font ",48"

--- a/gh-age.plot
+++ b/gh-age.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Monthly GitHub closed issue age" font ",48"

--- a/gh-fixes.plot
+++ b/gh-fixes.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "GitHub: issue life time until fixed\n{/*0.6For issues closed via a git commit message keyword}" font ",48"

--- a/gh-monthly-open.plot
+++ b/gh-monthly-open.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "GitHub: open issues and pull-requests" font ",48"

--- a/gh-monthly.plot
+++ b/gh-monthly.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "GitHub: created issues + pull-requests" font ",48"

--- a/gh-open.plot
+++ b/gh-open.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "GitHub: open issues and pull requests" font ",48"

--- a/graph-graphs.plot
+++ b/graph-graphs.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Number of graphs on the dashboard showing number of graphs on the dashboard" font ",32"

--- a/graphs.plot
+++ b/graphs.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Graphs in the curl dashboard\n{/*0.4Yes, it includes this one}" font ",48"

--- a/h1-per-year.plot
+++ b/h1-per-year.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "security reports on Hackerone" font ",48"

--- a/heatmap-releasedays.plot
+++ b/heatmap-releasedays.plot
@@ -1,5 +1,4 @@
-# SVG output
-set terminal svg size 1920,380 dynamic font ",24"
+set terminal svg size 1920,380 dynamic font ",24" background rgb 'white'
 
 set title "Release weekday heatmap" font ",48"
 

--- a/heatmap-weekhour.plot
+++ b/heatmap-weekhour.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,580 dynamic font ",24"
+set terminal svg size 1920,580 dynamic font ",24" background rgb 'white'
 
 set title "commits authored at this UTC week hour" font ",48"
 

--- a/high-vuln-reports.plot
+++ b/high-vuln-reports.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Vulnerability severity since 2010\n{/*0.4per report date}" font ",48"

--- a/http-over-time.plot
+++ b/http-over-time.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Supported HTTP versions" font ",48"

--- a/ifdef-over-time.plot
+++ b/ifdef-over-time.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "#if density\n{/*0.6#if, #elif, #ifdef and #ifndef instances in product code}" font ",48"

--- a/knownvulns-per-line.plot
+++ b/knownvulns-per-line.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Vulnerability density" font ",48"

--- a/line-complex.plot
+++ b/line-complex.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Source code line complexity\n{/*0.4Average and median cyclomatic complexity per production source code line}" font ",48"

--- a/lines-over-time.plot
+++ b/lines-over-time.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Lines of code (incl comments)" font ",48"

--- a/lines-per-author.plot
+++ b/lines-per-author.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Number of authors and contributors per KLOC" font ",48"

--- a/lines-per-docs.plot
+++ b/lines-per-docs.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Lines of docs per KLOC" font ",48"

--- a/lines-per-knownvulns.plot
+++ b/lines-per-knownvulns.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Lines of code per known vulnerability\n{/*0.4later data is too early to be fair}" font ",48"

--- a/lines-per-month.plot
+++ b/lines-per-month.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Product LOC delta per month" font ",48"

--- a/lines-per-test.plot
+++ b/lines-per-test.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Number of test cases per KLOC" font ",48"

--- a/lines-person.plot
+++ b/lines-person.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Added and removed lines in entire repo" font ",48"

--- a/loc-per-day.plot
+++ b/loc-per-day.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 set title "Lines of code growth" font ",48"
 set key top left
 set ylabel "Lines of code per day of existence"

--- a/mail.plot
+++ b/mail.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Mailing list posts per month" font ",48"

--- a/manpage-lines-per-option.plot
+++ b/manpage-lines-per-option.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Lines in curl.1 man page per command line option" font ",48"

--- a/manpage.plot
+++ b/manpage.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Number of lines in the curl.1 man page" font ",48"

--- a/manpages-over-time.plot
+++ b/manpages-over-time.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Man pages" font ",48"

--- a/month-of-year.plot
+++ b/month-of-year.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Commits per month" font ",48"

--- a/multi-handle.plot
+++ b/multi-handle.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Multi handle struct size" font ",48"

--- a/planets-over-time.plot
+++ b/planets-over-time.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Number of planets running curl" font ",48"

--- a/project-age.plot
+++ b/project-age.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 set title "Project age" font ",48"
 set key top left
 set ylabel "Days since"

--- a/protocols-over-time.plot
+++ b/protocols-over-time.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Transfer protocols" font ",48"

--- a/release-number.plot
+++ b/release-number.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "releases" font ",48"

--- a/releases-per-year.plot
+++ b/releases-per-year.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "releases per year" font ",48"

--- a/remains-per-kloc.plot
+++ b/remains-per-kloc.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Author density\n{/*0.6Number of authors still shown in git blame in product code per KLOC}" font ",48"

--- a/setopts-over-time.plot
+++ b/setopts-over-time.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "easy setopt options" font ",48"

--- a/sev-per-year.plot
+++ b/sev-per-year.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Vulnerability reports high vs low" font ",48"

--- a/severity.plot
+++ b/severity.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Severity distribution among all curl vulnerability reports accumulated" font ",48"

--- a/sscanf-over-time.plot
+++ b/sscanf-over-time.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "sscanf density" font ",48"

--- a/strcpy-over-time.plot
+++ b/strcpy-over-time.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 set title "strcpy density" font ",48"
 set key bottom center

--- a/strncpy-over-time.plot
+++ b/strncpy-over-time.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "strncpy density" font ",48"

--- a/symbols-over-time.plot
+++ b/symbols-over-time.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Public symbols exposed in headers" font ",48"

--- a/terminal.include
+++ b/terminal.include
@@ -1,0 +1,1 @@
+set terminal svg size 1920,1080 dynamic font ",24" background rgb 'white'

--- a/testinfra-over-time.plot
+++ b/testinfra-over-time.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Lines of test infrastructure" font ",48"

--- a/testinfra-per-line.plot
+++ b/testinfra-per-line.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Lines of test infra per KLOC" font ",48"

--- a/testinfra-per-test.plot
+++ b/testinfra-per-test.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Lines of test infra per test case" font ",48"

--- a/tests-over-time.plot
+++ b/tests-over-time.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Test cases" font ",48"

--- a/tls-over-time.plot
+++ b/tls-over-time.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "TLS backends" font ",48"

--- a/todo-over-time.plot
+++ b/todo-over-time.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Items listed in TODO and KNOWN BUGS" font ",48"

--- a/top-cwe.plot
+++ b/top-cwe.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Top CWE reasons used in curl CVE reports" font ",48"

--- a/top-remains.plot
+++ b/top-remains.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Top-40 authors with production code remaining in master" font ",48"

--- a/vuln-dist-code.plot
+++ b/vuln-dist-code.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Vulnerabilities present in curl code" font ",48"

--- a/vulns-over-time.plot
+++ b/vulns-over-time.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Fixed and created security vulnerabilities" font ",48"

--- a/vulns-per-year.plot
+++ b/vulns-per-year.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Vulnerabilities Fixed/Introduced" font ",48"

--- a/vulns-releases.plot
+++ b/vulns-releases.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Vulnerabilities in releases\n{/*0.4Every 4th release has a label}" font ",48"

--- a/weekday-of-year.plot
+++ b/weekday-of-year.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Commits per UTC weekday" font ",48"

--- a/words-over-time.plot
+++ b/words-over-time.plot
@@ -1,5 +1,5 @@
 # SVG output
-set terminal svg size 1920,1080 dynamic font ",24"
+load "stats/terminal.include"
 
 # title
 set title "Number of words" font ",48"


### PR DESCRIPTION
Make all gnuplot files include the "terminal.include" file which now also sets white background to make them work better even in dark mode etc.