### PR TITLE
knownvulns-per-line.plot: add average and median date markers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -256,8 +256,11 @@ $(DDIR)/lines-per-contributor.csv:$(DDIR)/contributors-over-time.csv $(DDIR)/lin
 $(DDIR)/lines-per-author.csv: $(DDIR)/authors.csv $(DDIR)/lines-over-time.csv $(SDIR)/plotdivision.pl
 	perl $(SDIR)/plotdivision.pl $(DDIR)/authors.csv $(DDIR)/lines-over-time.csv 0:2 0:1 1000 > $@
 
-$(GDIR)/knownvulns-per-line.svg: $(INCLUDE) $(DDIR)/knownvulns-per-line.csv $(DDIR)/known-low-per-line.csv $(DDIR)/known-med-per-line.csv $(DDIR)/known-high-per-line.csv $(DDIR)/known-crit-per-line.csv $(SDIR)/knownvulns-per-line.plot
-	$(GNUPLOT)
+$(DDIR)/dates.csv: $(DDIR)/cve-age.csv
+	perl $(SDIR)/gendates.pl $< > $@
+
+$(GDIR)/knownvulns-per-line.svg: $(INCLUDE) $(DDIR)/knownvulns-per-line.csv $(DDIR)/known-low-per-line.csv $(DDIR)/known-med-per-line.csv $(DDIR)/known-high-per-line.csv $(DDIR)/known-crit-per-line.csv $(SDIR)/knownvulns-per-line.plot $(DDIR)/dates.csv
+	gnuplot -c $(SDIR)/$(basename $(notdir $@)).plot $(DDIR) `cut -d";" -f1 < $(DDIR)/dates.csv` `cut -d";" -f2 < $(DDIR)/dates.csv` > $@
 $(DDIR)/knownvulns-per-line.csv: $(DDIR)/vulns-releases.csv $(DDIR)/lines-over-time.csv $(SDIR)/plotdivision.pl
 	perl $(SDIR)/plotdivision.pl $(DDIR)/vulns-releases.csv $(DDIR)/lines-over-time.csv 0:2 0:1 1000 > $@
 $(DDIR)/known-low-per-line.csv: $(DDIR)/vulns-releases.csv $(DDIR)/lines-over-time.csv $(SDIR)/plotdivision.pl

--- a/gendates.pl
+++ b/gendates.pl
@@ -1,0 +1,33 @@
+#!/usr/bin/perl
+
+# Convert average and median ages to dates in the past
+
+my $csv = $ARGV[0];
+
+my $average;
+my $median;
+
+open(F, "<$csv") or die "can't open";
+while(<F>) {
+    my $l = $_;
+    my @a = split(/;/, $l);
+    $average = $a[5];
+    $median = $a[6];
+}
+close(F);
+
+# This gets the times in *years*.
+
+#print "$median $average\n";
+
+my $meddays = int($median * 365.25);
+my $avdays = int($average * 365.25);
+#printf "%u %u days\n", $meddays, $avdays;
+
+my $m = `date -d "$meddays days ago" +"%Y-%m-%d"`;
+my $a= `date -d "$avdays days ago" +"%Y-%m-%d"`;
+
+chomp $m;
+chomp $a;
+
+print "$m;$a\n";

--- a/knownvulns-per-line.plot
+++ b/knownvulns-per-line.plot
@@ -25,7 +25,7 @@ set datafile separator ";"
 
 set arrow from ARG2, 0.0 to ARG2, 1 nohead linecolor rgb "#000000" linewidth 5 front
 
-set label "medium vulnerability age ".ARG2 at ARG2, 1.05 center textcolor rgb "#666666" font ",22" rotate by -22
+set label "median vulnerability age ".ARG2 at ARG2, 1.05 center textcolor rgb "#666666" font ",22" rotate by -22
 
 set arrow 2 from ARG3, 0.0 to ARG3, 1.2 nohead linecolor rgb "#000000" linewidth 5 front
 

--- a/knownvulns-per-line.plot
+++ b/knownvulns-per-line.plot
@@ -23,11 +23,11 @@ load "stats/logo.include"
 set format x "%Y"
 set datafile separator ";"
 
-set arrow from ARG2, 0.0 to ARG2, 1 nohead linecolor rgb "#000000" linewidth 5 front
+set arrow from ARG2, 1 to ARG2, 0 linecolor rgb "#000000" linewidth 5 front
 
 set label "median vulnerability age ".ARG2 at ARG2, 1.05 center textcolor rgb "#666666" font ",22" rotate by -22
 
-set arrow 2 from ARG3, 0.0 to ARG3, 1.2 nohead linecolor rgb "#000000" linewidth 5 front
+set arrow 2 from ARG3, 1.2 to ARG3, 0 linecolor rgb "#000000" linewidth 5 front
 
 set label "average vulnerability age ".ARG3 at ARG3, 1.25 center textcolor rgb "#666666" font ",22" rotate by -22
 

--- a/knownvulns-per-line.plot
+++ b/knownvulns-per-line.plot
@@ -22,6 +22,15 @@ load "stats/logo.include"
 
 set format x "%Y"
 set datafile separator ";"
+
+set arrow from ARG2, 0.0 to ARG2, 1 nohead linecolor rgb "#000000" linewidth 5 front
+
+set label "medium vulnerability age ".ARG2 at ARG2, 1.05 center textcolor rgb "#666666" font ",22" rotate by -22
+
+set arrow 2 from ARG3, 0.0 to ARG3, 1.2 nohead linecolor rgb "#000000" linewidth 5 front
+
+set label "average vulnerability age ".ARG3 at ARG3, 1.25 center textcolor rgb "#666666" font ",22" rotate by -22
+
 plot ARG1.'/known-low-per-line.csv' using 1:2 with filledcurves fc "#2e8a00" title "Low", \
  ARG1.'/known-med-per-line.csv' using 1:2 with filledcurves fc "#0080c0" title "Medium", \
  ARG1.'/known-high-per-line.csv' using 1:2 with filledcurves fc "#800000" title "High", \


### PR DESCRIPTION
Add two lines that mark the specific dates on the x-axis for the average and median times vulnerbilities are present when reported, converted to specific dates counted from today.

## Preview

<img width="2807" height="1931" alt="image" src="https://github.com/user-attachments/assets/06266669-f4a3-4c91-a88a-e6ee64792cea" />
